### PR TITLE
Fix ImportError with CircuitPython 2.0.0 on ESP8266

### DIFF
--- a/libs/PewPewLite4.0/pew.py
+++ b/libs/PewPewLite4.0/pew.py
@@ -2,7 +2,10 @@ from micropython import const
 import board
 import busio
 import digitalio
-import neopixel_write
+try:
+    import neopixel_write
+except ImportError:
+    pass
 import time
 
 


### PR DESCRIPTION
On my Feather Huzzah (ESP8266) with CircuitPython 2.0.0, `import pew` fails with an ImportError because there appears to be no `neopixel_write` module. Having never used CircuitPython before, I have no idea if that’s the way it’s supposed to be, if this is new in version 2.0, or anything, but I can fix it by just skipping the neopixel initialization because the Huzzah does not have an onboard neopixel anyway.

There is a `neopixel` module with a working `neopixel_write` function, but it’s the one from MicroPython that takes a `machine.Pin`, not a `digitalio.DigitalInOut`.

(I have finally gotten around to assembling the PewPew I bought at Maker Faire Zürich, and I’m relieved the initial problems I had with it were in the software, not in faulty hardware. I am having fun with it and it’s refreshing my urge to develop a MicroPython workshop for FabLab Winti. Very cool hardware and software!)