### PR TITLE
Fix missing red in the rightmost column

### DIFF
--- a/libs/PewPewLite4.0/pew.py
+++ b/libs/PewPewLite4.0/pew.py
@@ -249,7 +249,7 @@ def init():
     except OSError:
         raise RuntimeError("PewPew Lite board not found")
     try:
-        _buffer[1:2] = b'\x00\x00'
+        _buffer[1:3] = b'\x00\x00'
     except TypeError:
         SLICES = False
 


### PR DESCRIPTION
On my Feather Huzzah (ESP8266) with CircuitPython 2.0.0, any red component drawn to the pixels in the rightmost column (next to the O/X buttons) is ignored, they light up green only.

I first suspected faulty components or soldering, but it’s actually a software bug: The assignment `_buffer[1:2] = b'\x00\x00'` mistakenly writes two bytes into a one-byte slice and thereby enlarges _buffer from 17 to 18 bytes. Sending the whole buffer to the LED controller in `show()` then wraps around to the beginning of the framebuffer and overwrites its first byte with zero.