### PR TITLE
Only show PewPew games in the menu

### DIFF
--- a/games/menu.py
+++ b/games/menu.py
@@ -74,13 +74,21 @@ def menu(entries):
         yield selected
 
 
+def importspew(name):
+    with open(name, 'r') as f:
+        for l in range(2):
+            if f.readline().strip() == 'import pew':
+                return True
+    return False
+
+
 pew.init()
 pew.init()
 while True:
     hold = 0
     screen = pew.Pix()
     files = [name[:-3] for name in os.listdir()
-             if name.endswith('.py') and name != 'main.py']
+             if name.endswith('.py') and name != 'main.py' and importspew(name)]
     m = menu(files)
     selected = 0
     try:


### PR DESCRIPTION
On the ESP8266, in addition to any PewPew games, I have files _boot.py_ and _webrepl_cfg.py_ in the filesystem root. There may be other libraries too. These all show up in the PewPew menu (menu.py), even though launching them as games makes no sense.

The attached commit filters the directory listing to files that are recognized as PewPew games by checking whether one of their first two lines is `import pew`. Specifying that it must be the first line would make the code even simpler, but this is currently not satisfied by _tetris.py_.

What do you think about this?