### PR TITLE
Fix relaunch after GameOver

### DIFF
--- a/games/main.py
+++ b/games/main.py
@@ -105,6 +105,6 @@ while True:
     try:
         __import__(game)
     except pew.GameOver:
-        continue
+        pass
     del sys.modules[game]
 


### PR DESCRIPTION
When a game is launched from the menu, then exits with a pew.GameOver exception (e.g. by pressing all four directional keys at once), then is selected from the menu again, it does not launch again, but the menu just restarts. Only at the next attempt it will launch normally again.

This is because in the case of the exception, the menu fails to remove the module from sys.modules, and therefore the next attempt to import it will not run it again. The attached commit fixes that.