### PR TITLE
Don’t let tick() accumulate unbounded backlog when called too infrequently

### DIFF
--- a/libs/PewPew3.0/pew.py
+++ b/libs/PewPew3.0/pew.py
@@ -56,9 +56,9 @@ def keys():
 
 def tick(delay):
     global _tick
-
-    _tick += delay
-    time.sleep(max(0, _tick - time.monotonic()))
+    now = time.monotonic()
+    _tick = max(_tick + delay, now)
+    time.sleep(max(0, _tick - now))
 
 
 class GameOver(Exception):
@@ -202,6 +202,7 @@ def init():
     global _i2c, _buffer, _temp, _tick, _page
     global SLICES
 
+    _tick = time.monotonic()
     _buffer = bytearray(17)
 
     if _i2c is not None:
@@ -211,7 +212,6 @@ def init():
     _i2c.try_lock()
     _temp = bytearray(2)
     _page = None
-    _tick = time.monotonic()
 
     try:
         _register(0x03, 0x00, 0x03)

--- a/libs/PewPew3.1/pew.py
+++ b/libs/PewPew3.1/pew.py
@@ -84,9 +84,9 @@ def keys():
 
 def tick(delay):
     global _tick
-
-    _tick += delay
-    time.sleep(max(0, _tick - time.monotonic()))
+    now = time.monotonic()
+    _tick = max(_tick + delay, now)
+    time.sleep(max(0, _tick - now))
 
 
 class GameOver(Exception):
@@ -229,6 +229,7 @@ def init():
     global _i2c, _buffer, _temp, _keys, _last_keys, _tick, _page, _key_pins
     global SLICES
 
+    _tick = time.monotonic()
     _buffer = bytearray(17)
 
     if _i2c is not None:
@@ -240,7 +241,6 @@ def init():
     _page = None
     _keys = 0
     _last_keys = 0
-    _tick = time.monotonic()
 
     try:
         _register(0x03, 0x00, 0x03)

--- a/libs/PewPew4.1/pew.py
+++ b/libs/PewPew4.1/pew.py
@@ -81,9 +81,9 @@ def keys():
 
 def tick(delay):
     global _tick
-
-    _tick += delay
-    time.sleep(max(0, _tick - time.monotonic()))
+    now = time.monotonic()
+    _tick = max(_tick + delay, now)
+    time.sleep(max(0, _tick - now))
 
 
 class GameOver(Exception):
@@ -225,6 +225,7 @@ def _register(page, register, value=None):
 def init():
     global _i2c, _buffer, _temp, _tick, _page, _gamepad
 
+    _tick = time.monotonic()
     _buffer = bytearray(17)
 
     if _i2c is not None:
@@ -236,7 +237,6 @@ def init():
     _page = None
     _keys = 0
     _last_keys = 0
-    _tick = time.monotonic()
 
     _register(0x03, 0x00, 0x03)
     _register(0x00, 0x00)

--- a/libs/PewPewD1Mini/pew.py
+++ b/libs/PewPewD1Mini/pew.py
@@ -96,9 +96,9 @@ def keys():
 
 def tick(delay):
     global _tick
-
-    _tick += delay
-    time.sleep(max(0, _tick - time.monotonic()))
+    now = time.monotonic()
+    _tick = max(_tick + delay, now)
+    time.sleep(max(0, _tick - now))
 
 
 class Pix:
@@ -205,6 +205,8 @@ class Pix:
 def init():
     global _i2c, _buffer, _temp, _keys, _last_keys, _tick
 
+    _tick = time.monotonic()
+
     if _i2c is not None:
         return
 
@@ -214,7 +216,6 @@ def init():
     _temp = bytearray(2)
     _keys = 0
     _last_keys = 0
-    _tick = time.monotonic()
 
     _buffer[0] = 0x21
     try:

--- a/libs/PewPewLite2.0/pew.py
+++ b/libs/PewPewLite2.0/pew.py
@@ -73,9 +73,9 @@ def keys():
 
 def tick(delay):
     global _tick
-
-    _tick += delay
-    time.sleep(max(0, _tick - time.monotonic()))
+    now = time.monotonic()
+    _tick = max(_tick + delay, now)
+    time.sleep(max(0, _tick - now))
 
 
 class Pix:
@@ -183,6 +183,8 @@ class Pix:
 def init():
     global _i2c, _buffer, _temp, _keys, _last_keys, _tick
 
+    _tick = time.monotonic()
+
     if _i2c is not None:
         return
 
@@ -192,7 +194,6 @@ def init():
     _temp = bytearray(2)
     _keys = 0
     _last_keys = 0
-    _tick = time.monotonic()
 
     _buffer[0] = 0x21
     try:

--- a/libs/PewPewLite4.0/pew.py
+++ b/libs/PewPewLite4.0/pew.py
@@ -86,9 +86,9 @@ def keys():
 
 def tick(delay):
     global _tick
-
-    _tick += delay
-    time.sleep(max(0, _tick - time.monotonic()))
+    now = time.monotonic()
+    _tick = max(_tick + delay, now)
+    time.sleep(max(0, _tick - now))
 
 
 class GameOver(Exception):
@@ -213,6 +213,7 @@ def init():
     global _i2c, _buffer, _temp, _keys, _last_keys, _tick
     global SLICES
 
+    _tick = time.monotonic()
     _buffer = bytearray(17)
 
     if _i2c is not None:
@@ -223,7 +224,6 @@ def init():
     _temp = bytearray(2)
     _keys = 0
     _last_keys = 0
-    _tick = time.monotonic()
 
     _buffer[0] = 0x21
     try:


### PR DESCRIPTION
See discussion in #5.

I only tested the PewPewLite4.0 part, but they are similar enough.

I also move the `_tick` initialization: It doesn’t matter as much anymore with the new code, but this is something that should be initialized by every game that calls `pew.init()`, not just the first one.