### PR TITLE
Provide the menu as a module

### DIFF
--- a/games/main.py
+++ b/games/main.py
@@ -105,6 +105,6 @@ while True:
     try:
         __import__(game)
     except pew.GameOver:
-        continue
+        pass
     del sys.modules[game]
 

--- a/games/main.py
+++ b/games/main.py
@@ -1,110 +1,17 @@
 import sys
 import os
-import time
 import pew
+import pew_menu
 
-
-def scroll(pix, dx=1):
-    x = 0
-    while True:
-        for x in range(x, pix.width, dx):
-            screen.box(0)
-            screen.blit(pix, -x, 1)
-            yield x
-        x = -8
-
-
-def change(pix, next_pix, x, dy):
-    for y in range(1, 1 + 8 * dy, dy):
-        screen.box(0)
-        screen.blit(pix, -x, y)
-        screen.blit(next_pix, 0, y - 7 * dy)
-        yield
-
-
-def hold_keys():
-    global hold
-
-    try:
-        keys = pew.keys()
-    except pew.GameOver:
-        keys = 0
-    if keys:
-        hold = 0
-    while pew.keys() and time.monotonic() - hold < 0.25:
-        return 0
-    hold = time.monotonic()
-    return keys
-
-
-def menu(entries):
-    brightness = 7
-    pew.brightness(brightness)
-    selected = 0
-    pix = pew.Pix.from_text(entries[selected])
-    x = 0
-    animation = scroll(pix)
-    while True:
-        keys = hold_keys()
-        if keys & pew.K_O:
-            return
-        if keys & pew.K_RIGHT:
-            brightness = min(brightness + 1, 15)
-            pew.brightness(brightness)
-        if keys & pew.K_LEFT:
-            brightness = max(brightness - 1, 0)
-            pew.brightness(brightness)
-        if keys & pew.K_UP:
-            selected = (selected - 1) % len(entries)
-            next_pix = pew.Pix.from_text(entries[selected])
-            yield from change(pix, next_pix, x, 1)
-            hold_keys()
-            pix = next_pix
-            animation = scroll(pix)
-            keys = 0
-        if keys & pew.K_DOWN:
-            selected = (selected + 1) % len(entries)
-            next_pix = pew.Pix.from_text(entries[selected])
-            yield from change(pix, next_pix, x, -1)
-            hold_keys()
-            pix = next_pix
-            animation = scroll(pix)
-            keys = 0
-        x = next(animation)
-        yield selected
-        yield selected
-
-
-pew.init()
 pew.init()
 while True:
-    hold = 0
-    screen = pew.Pix()
     files = [name[:-3] for name in os.listdir()
              if name.endswith('.py') and name != 'main.py']
-    m = menu(files)
-    selected = 0
-    try:
-        while pew.keys():
-            pew.tick(1/24)
-    except pew.GameOver:
-        pass
-    while True:
-        try:
-            selected = next(m)
-        except StopIteration:
-            break
-        pew.show(screen)
-        pew.tick(1/24)
-    screen.box(0)
-    pew.show(screen)
+    selected = pew_menu.menu(files)
     game = files[selected]
-    del screen
-    del m
     del files
     try:
         __import__(game)
     except pew.GameOver:
         pass
     del sys.modules[game]
-

--- a/games/pew_menu.py
+++ b/games/pew_menu.py
@@ -1,0 +1,96 @@
+import time
+import pew
+
+
+def scroll(screen, pix, dx=1):
+    x = 0
+    while True:
+        for x in range(x, pix.width, dx):
+            screen.box(0)
+            screen.blit(pix, -x, 1)
+            yield x
+        x = -8
+
+
+def change(screen, pix, next_pix, x, dy):
+    for y in range(1, 1 + 8 * dy, dy):
+        screen.box(0)
+        screen.blit(pix, -x, y)
+        screen.blit(next_pix, 0, y - 7 * dy)
+        yield
+
+
+hold = 0
+
+def hold_keys():
+    global hold
+
+    try:
+        keys = pew.keys()
+    except pew.GameOver:
+        keys = 0
+    if keys:
+        hold = 0
+    while pew.keys() and time.monotonic() - hold < 0.25:
+        return 0
+    hold = time.monotonic()
+    return keys
+
+
+def menugen(screen, entries):
+    try:
+        while pew.keys():
+            pew.tick(1/24)
+    except pew.GameOver:
+        pass
+    brightness = 7
+    pew.brightness(brightness)
+    selected = 0
+    pix = pew.Pix.from_text(entries[selected])
+    x = 0
+    animation = scroll(screen, pix)
+    while True:
+        keys = hold_keys()
+        if keys & pew.K_O:
+            return
+        if keys & pew.K_RIGHT:
+            brightness = min(brightness + 1, 15)
+            pew.brightness(brightness)
+        if keys & pew.K_LEFT:
+            brightness = max(brightness - 1, 0)
+            pew.brightness(brightness)
+        if keys & pew.K_UP:
+            selected = (selected - 1) % len(entries)
+            next_pix = pew.Pix.from_text(entries[selected])
+            yield from change(screen, pix, next_pix, x, 1)
+            hold_keys()
+            pix = next_pix
+            animation = scroll(screen, pix)
+            keys = 0
+        if keys & pew.K_DOWN:
+            selected = (selected + 1) % len(entries)
+            next_pix = pew.Pix.from_text(entries[selected])
+            yield from change(screen, pix, next_pix, x, -1)
+            hold_keys()
+            pix = next_pix
+            animation = scroll(screen, pix)
+            keys = 0
+        x = next(animation)
+        yield selected
+        yield selected
+
+
+def menu(entries):
+    screen = pew.Pix()
+    m = menugen(screen, entries)
+    selected = 0
+    while True:
+        try:
+            selected = next(m)
+        except StopIteration:
+            break
+        pew.show(screen)
+        pew.tick(1/24)
+    screen.box(0)
+    pew.show(screen)
+    return selected

--- a/games/pew_menu.py
+++ b/games/pew_menu.py
@@ -46,7 +46,8 @@ def menugen(screen, entries):
     brightness = 7
     pew.brightness(brightness)
     selected = 0
-    pix = pew.Pix.from_text(entries[selected])
+    selectedText = entries[selected]
+    pix = pew.Pix.from_text(selectedText)
     x = 0
     animation = scroll(screen, pix)
     while True:
@@ -61,7 +62,8 @@ def menugen(screen, entries):
             pew.brightness(brightness)
         if keys & pew.K_UP:
             selected = (selected - 1) % len(entries)
-            next_pix = pew.Pix.from_text(entries[selected])
+            selectedText = entries[selected]
+            next_pix = pew.Pix.from_text(selectedText)
             yield from change(screen, pix, next_pix, x, 1)
             hold_keys()
             pix = next_pix
@@ -69,7 +71,8 @@ def menugen(screen, entries):
             keys = 0
         if keys & pew.K_DOWN:
             selected = (selected + 1) % len(entries)
-            next_pix = pew.Pix.from_text(entries[selected])
+            selectedText = entries[selected]
+            next_pix = pew.Pix.from_text(selectedText)
             yield from change(screen, pix, next_pix, x, -1)
             hold_keys()
             pix = next_pix
@@ -78,6 +81,15 @@ def menugen(screen, entries):
         x = next(animation)
         yield selected
         yield selected
+        if selected >= len(entries) or entries[selected] != selectedText:
+            try:
+                selected = entries.index(selectedText)
+            except ValueError:
+                if selected >= len(entries):
+                    selected = len(entries) - 1
+                selectedText = entries[selected]
+                pix = pew.Pix.from_text(selectedText)
+                animation = scroll(screen, pix)
 
 
 def menu(entries):


### PR DESCRIPTION
The attached commits split the menu functionality of _main.py_ out into a module `pew_menu` that can be used by applications, e.g. for configuration, level selection, or in my case, a lobby for online players.

It exports two functions:
- `menu(entries)`: Runs the menu with the given list of strings, blocking until the user has selected one, and returns the index of the selected entry.
- `menugen(screen, entries)`: A generator that allows background processing while the menu is running, intended to be used like
```python
for selected in pew_menu.menugen(screen, entries):
	do_other_stuff()
	pew.show(screen)
	pew.tick(1/24)
```
`do_other_stuff()` may modify `entries`, and modifications appear in the menu live.

Open questions:
- All naming is up for debate.
- Should the module move from _games/_ into _libs/_? It’s more a library than a game, but is not platform-specific.
- I plan to supply documentation once we have a consensus about the code.

Includes #4.
